### PR TITLE
Add Leaderboard Screen

### DIFF
--- a/__tests__/app/api/submit.test.js
+++ b/__tests__/app/api/submit.test.js
@@ -6,6 +6,7 @@ import { POST } from "../../../app/api/submit/route";
 const requestObj = {
   json: async () => ({
     answers: { 0: 1, 1: 0, 2: 2 },
+    userName: "Player 1"
   }),
 };
 

--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -1,8 +1,15 @@
 import { UserAnswers } from "@/types/quiz";
 import questions from "../questions/questions.json";
 import leaderboard from "./leaderboard.json";
+
 export async function POST(request: Request) {
-  const { answers }: { answers: UserAnswers } = await request.json();
+  const {
+    answers,
+    userName,
+  }: {
+    answers: UserAnswers;
+    userName: string;
+  } = await request.json();
 
   let checkedAnswers = Object.entries(answers).map(
     ([questionIndex, answer]) => {
@@ -13,11 +20,11 @@ export async function POST(request: Request) {
     }
   );
 
-  const userName = "Player 1";
-  const userScore = checkedAnswers.filter(answer => answer.correct).length;
+  const userScore = checkedAnswers.filter((answer) => answer.correct).length;
   // Assing a random skill of 0-3000 to their score to make it more interesting
   const skillScore = Math.floor(Math.random() * 3000);
   const totalScore = userScore + skillScore;
+
   const leaderboardWithNewUser = [
     ...leaderboard,
     { id: crypto.randomUUID(), name: userName, score: totalScore },
@@ -25,12 +32,17 @@ export async function POST(request: Request) {
 
   leaderboardWithNewUser.sort((a, b) => b.score - a.score);
 
+  const leaderboardWithRanks = leaderboardWithNewUser?.map((item, i) => ({
+    ...item,
+    rank: i + 1,
+  }));
+
   return Response.json({
     answers: checkedAnswers,
     userScore,
     skillScore,
     totalScore,
-    leaderboard: leaderboardWithNewUser,
+    leaderboard: leaderboardWithRanks,
     userName,
   });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,12 @@
 :root {
+  --bg-light-color: #f3f3f3;
   --text-color: #40444f;
   --text-secondary-color: #652f00;
+  --text-light-color: #666;
   --primary-color: #ffae28;
   --border-color: #f3f3f3;
   --active-color: #1374e2;
+  --error-color: red;
   --border-radius: 10px;
   --border-radius-small: 5px;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,20 @@
+:root {
+  --text-color: #40444f;
+  --text-secondary-color: #652f00;
+  --primary-color: #ffae28;
+  --border-color: #f3f3f3;
+  --active-color: #1374e2;
+  --border-radius: 10px;
+  --border-radius-small: 5px;
+}
+
 html,
 body {
   padding: 0;
   margin: 0;
   font-family: Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
     Helvetica Neue, sans-serif;
-  color: #40444f;
+  color: var(--text-color);
 }
 
 a {
@@ -14,4 +24,21 @@ a {
 
 * {
   box-sizing: border-box;
+}
+
+button {
+  cursor: pointer;
+  font-family: inherit;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.sr-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Roboto } from "next/font/google";
+import { AppWrapper } from "@/context/quiz";
 import styles from "./layout.module.css";
 import "./globals.css";
 
@@ -21,7 +22,9 @@ export default function RootLayout({
   return (
     <html lang="en" className={roboto.className}>
       <body>
-        <div className={styles.container}>{children}</div>
+        <AppWrapper>
+          <div className={styles.container}>{children}</div>
+        </AppWrapper>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import Button from "../components/button";
+import UserNameForm from "@/components/quiz/userNameForm";
 import styles from "./page.module.css";
 
 export default function Home() {
@@ -6,9 +6,7 @@ export default function Home() {
     <div className={styles.page}>
       <main className={styles.main}>
         <h1 className={styles.title}>Book Creator Quiz</h1>
-        <Button large href="/quiz/question/1">
-          Start
-        </Button>
+        <UserNameForm />
       </main>
     </div>
   );

--- a/app/quiz/complete/page.module.css
+++ b/app/quiz/complete/page.module.css
@@ -1,9 +1,10 @@
 .container {
+  padding-top: 40px;
+  padding-bottom: 60px;
 }
 
-.score {
-  font-size: 18px;
-  max-width: 500px;
-  margin: 0 auto;
+.title {
+  margin-bottom: 30px;
+  margin-top: 0;
   text-align: center;
 }

--- a/app/quiz/complete/page.tsx
+++ b/app/quiz/complete/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { QuizContext } from "../../../context/quiz";
-import styles from "./page.module.css";
+import { QuizContext } from "@/context/quiz";
 import { QuizResult } from "@/types/quiz";
 import UserResult from "@/components/quiz/userResult";
-import PlayersResult from "@/components/quiz/playersList";
+import PlayersResult from "@/components/quiz/playersResult";
+import styles from "./page.module.css";
 
 export default function QuizComplete() {
   const { userAnswers, questions, userName } = useContext(QuizContext);
@@ -44,7 +44,7 @@ export default function QuizComplete() {
 
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>Quize Summary</h1>
+      <h1 className={styles.title}>Quiz Summary</h1>
       <UserResult
         skillScore={skillScore}
         totalQuestions={questions?.length}

--- a/app/quiz/complete/page.tsx
+++ b/app/quiz/complete/page.tsx
@@ -3,10 +3,12 @@ import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { QuizContext } from "../../../context/quiz";
 import styles from "./page.module.css";
-import { QuizResult, UserAnswers } from "@/types/quiz";
+import { QuizResult } from "@/types/quiz";
+import UserResult from "@/components/quiz/userResult";
+import PlayersResult from "@/components/quiz/playersList";
 
 export default function QuizComplete() {
-  const { userAnswers } = useContext(QuizContext);
+  const { userAnswers, questions, userName } = useContext(QuizContext);
   const router = useRouter();
   const [result, setResult] = useState<QuizResult>();
   const [failed, setFailed] = useState(false);
@@ -21,7 +23,7 @@ export default function QuizComplete() {
       try {
         const res = await fetch("/api/submit", {
           method: "POST",
-          body: JSON.stringify({ answers: userAnswers }),
+          body: JSON.stringify({ answers: userAnswers, userName }),
           headers: {
             "Content-Type": "application/json",
           },
@@ -38,18 +40,19 @@ export default function QuizComplete() {
 
   if (!result) return null;
 
-  const { userName, userScore, skillScore, totalScore, leaderboard } = result;
-
-  console.log({ leaderboard });
+  const { userScore, skillScore, totalScore, leaderboard } = result;
 
   return (
     <div className={styles.container}>
-      <p className={styles.score}>
-        🎉 <strong>{userName}</strong>, you answered{" "}
-        <strong>{userScore}</strong> questions correctly and gained a skill
-        score of <strong>{skillScore}</strong>, giving you a total score of{" "}
-        <strong>{totalScore}</strong> 🎉
-      </p>
+      <h1 className={styles.title}>Quize Summary</h1>
+      <UserResult
+        skillScore={skillScore}
+        totalQuestions={questions?.length}
+        totalScore={totalScore}
+        userName={userName}
+        userScore={userScore}
+      />
+      <PlayersResult leaderboard={leaderboard} />
     </div>
   );
 }

--- a/app/quiz/layout.tsx
+++ b/app/quiz/layout.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from "next";
 import Header from "../../components/header";
 import Page from "../../components/page";
 import Content from "../../components/content";
-import { AppWrapper } from "../../context/quiz";
 
 // export const metadata: Metadata = {
 //   title: "Book Creator Quiz",
@@ -16,11 +15,9 @@ export default function QuizLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <AppWrapper>
-      <Page>
-        <Header title="Book Creator" subtitle="Quiz" />
-        <Content>{children}</Content>
-      </Page>
-    </AppWrapper>
+    <Page>
+      <Header title="Book Creator" subtitle="Quiz" />
+      <Content>{children}</Content>
+    </Page>
   );
 }

--- a/app/quiz/question/[number]/page.module.css
+++ b/app/quiz/question/[number]/page.module.css
@@ -3,7 +3,7 @@
   display: block;
   font-size: 24px;
   margin: 0 auto 0.5em;
-  color: #666;
+  color: var(--text-light-color);
 }
 
 .questionNumber small {

--- a/components/button/index.module.css
+++ b/components/button/index.module.css
@@ -21,7 +21,7 @@
 }
 
 .button:not(:disabled):hover {
-  background: #ffae28;
+  background: var(--primary-color);
 }
 
 .large {
@@ -47,7 +47,7 @@
 }
 
 .button.text:hover {
-  background: #f3f3f3;
+  background: var(--bg-light-color);
 }
 
 .icon {
@@ -56,9 +56,9 @@
 }
 
 .text.secondary {
-  color: #666;
+  color: var(--text-light-color);
 }
 
 .text.secondary .icon {
-  fill: #666;
+  fill: var(--text-light-color);
 }

--- a/components/button/index.module.css
+++ b/components/button/index.module.css
@@ -1,9 +1,9 @@
 .button {
   background: #1374e2;
-  border-radius: 5px;
+  border-radius: var(--border-radius-small);
   border: none;
   background: linear-gradient(180deg, #ffd600 0%, #ffcd1d 6.96%, #ffae28 100%);
-  color: #652f00;
+  color: var(--text-secondary-color);
   font-size: 18px;
   padding: 10px 20px;
   font-weight: 500;
@@ -26,8 +26,14 @@
 
 .large {
   font-size: 28px;
-  border-radius: 10px;
+  border-radius: var(--border-radius);
   padding: 15px 30px;
+}
+
+.small {
+  font-size: 16px;
+  padding-left: 15px;
+  padding-right: 15px;
 }
 
 .text,

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import SvgIcon from "../svg-icon";
 import cx from "classnames";
+import { IconType } from "@/types/common";
 import styles from "./index.module.css";
 
 interface ButtonProps {
@@ -8,11 +9,14 @@ interface ButtonProps {
   disabled?: boolean;
   onClick?: () => void;
   large?: boolean;
+  small?: boolean;
   href?: string;
   style?: React.CSSProperties;
   text?: boolean;
-  icon?: string;
+  icon?: IconType;
   secondary?: boolean;
+  type?: string;
+  buttonClassName?: string;
 }
 
 export default function Button(props: ButtonProps) {
@@ -21,18 +25,25 @@ export default function Button(props: ButtonProps) {
     disabled,
     onClick,
     large,
+    small,
     href,
     style,
     text,
     icon,
     secondary,
+    buttonClassName,
   } = props;
 
-  const className = cx(styles.button, {
-    [styles.large]: large,
-    [styles.text]: text,
-    [styles.secondary]: secondary,
-  });
+  const className = cx(
+    styles.button,
+    {
+      [styles.large]: large,
+      [styles.small]: small,
+      [styles.text]: text,
+      [styles.secondary]: secondary,
+    },
+    buttonClassName
+  );
 
   const sharedProps = {
     className,
@@ -41,14 +52,20 @@ export default function Button(props: ButtonProps) {
     disabled,
   };
 
+  const content = (
+    <>
+      {icon && <SvgIcon icon={icon} className={styles.icon} />}
+      {children}
+    </>
+  );
+
   if (href) {
     return (
       <Link href={href} {...sharedProps}>
-        {icon ? <SvgIcon icon={icon} className={styles.icon} /> : null}
-        {children}
+        {content}
       </Link>
     );
   }
 
-  return <button {...sharedProps}>{children}</button>;
+  return <button {...sharedProps}>{content}</button>;
 }

--- a/components/checkbox/index.module.css
+++ b/components/checkbox/index.module.css
@@ -7,7 +7,7 @@
 }
 
 .container.checked {
-  border-color: #1374e2;
+  border-color: var(--active-color);
 }
 
 .tick {
@@ -15,7 +15,7 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  fill: #1374e2;
+  fill: var(--active-color);
   width: 16px;
   height: 16px;
 }

--- a/components/formGroup/index.module.css
+++ b/components/formGroup/index.module.css
@@ -8,7 +8,7 @@
 }
 
 .error {
-  color: red;
+  color: var(--error-color);
   font-size: 14px;
   margin-top: 5px;
   margin-left: 5px;

--- a/components/formGroup/index.module.css
+++ b/components/formGroup/index.module.css
@@ -1,0 +1,15 @@
+.group:not(:only-child):not(:last-child) {
+  margin-bottom: 20px;
+}
+
+.label {
+  display: block;
+  margin-bottom: 5px;
+}
+
+.error {
+  color: red;
+  font-size: 14px;
+  margin-top: 5px;
+  margin-left: 5px;
+}

--- a/components/formGroup/index.tsx
+++ b/components/formGroup/index.tsx
@@ -1,0 +1,38 @@
+import cx from "classnames";
+import styles from "./index.module.css";
+
+interface FormGroupProps {
+  children: React.ReactNode;
+  className?: string;
+  error?: string;
+  htmlFor?: string;
+  isLabelHidden?: boolean;
+  label: string;
+  required?: boolean;
+}
+
+export default function FormGroup(props: FormGroupProps) {
+  const {
+    children,
+    className,
+    error,
+    htmlFor,
+    isLabelHidden,
+    label,
+    required,
+  } = props;
+
+  return (
+    <div className={cx(styles.group, className)}>
+      <label
+        className={cx(styles.label, { "sr-only": isLabelHidden })}
+        htmlFor={htmlFor}
+      >
+        {label}
+        {required && <span className={styles.required}>*</span>}
+      </label>
+      {children}
+      {error && <div className={styles.error}>{error}</div>}
+    </div>
+  );
+}

--- a/components/input/index.module.css
+++ b/components/input/index.module.css
@@ -1,0 +1,19 @@
+.input {
+  border-radius: var(--border-radius-small);
+  border: 1px solid #ccc;
+  color: inherit;
+  font-size: 16px;
+  height: 36px;
+  padding: 10px 15px;
+  width: 100%;
+}
+
+.input:focus {
+  border-color: var(--active-color);
+}
+
+.large {
+  border-radius:  var(--border-radius);
+  height: 60px;
+  padding: 15px 20px;
+}

--- a/components/input/index.tsx
+++ b/components/input/index.tsx
@@ -1,0 +1,40 @@
+import cx from "classnames";
+import styles from "./index.module.css";
+import { InputElementType, TextareaElementType } from "@/types/form";
+
+interface CommonProps {
+  className?: string;
+  large?: boolean;
+  ref?: React.Ref<HTMLInputElement | HTMLTextAreaElement>;
+  variant: "input" | "textarea";
+}
+
+type InputFieldType =
+  | (InputElementType & { variant: "input" })
+  | (TextareaElementType & { variant: "textarea" });
+
+type InputProps = CommonProps & InputFieldType;
+
+export default function Input(props: InputProps) {
+  const { className, large, ref, variant, ...rest } = props;
+  const classes = cx(styles.input, { [styles.large]: large }, className);
+
+  return (
+    <>
+      {variant === "input" && (
+        <input
+          className={classes}
+          ref={ref as React.Ref<HTMLInputElement>}
+          {...(rest as InputElementType)}
+        />
+      )}
+      {variant === "textarea" && (
+        <textarea
+          className={classes}
+          ref={ref as React.Ref<HTMLTextAreaElement>}
+          {...(rest as TextareaElementType)}
+        />
+      )}
+    </>
+  );
+}

--- a/components/pagination/index.module.css
+++ b/components/pagination/index.module.css
@@ -1,0 +1,18 @@
+.pagination {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.paginationList {
+  display: flex;
+  gap: 5px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+button.selected {
+  background: #f2f2f2;
+}

--- a/components/pagination/index.module.css
+++ b/components/pagination/index.module.css
@@ -14,5 +14,5 @@
 }
 
 button.selected {
-  background: #f2f2f2;
+  background: var(--bg-light-color);
 }

--- a/components/pagination/index.tsx
+++ b/components/pagination/index.tsx
@@ -1,0 +1,90 @@
+import cx from "classnames";
+import Button from "@/components/button";
+import styles from "./index.module.css";
+
+interface PaginationProps {
+  className?: string;
+  currentPage: number;
+  itemsPerPage: number;
+  onPageChange: (value: number) => void;
+  totalItems: number;
+}
+
+const MAX_LIMIT = 5;
+
+export default function Pagination(props: PaginationProps) {
+  const { className, currentPage, itemsPerPage, onPageChange, totalItems } =
+    props;
+
+  const totalPageNumber = Math.ceil(totalItems / itemsPerPage);
+
+  const handlePrevious = () => {
+    if (currentPage < 1) return;
+    onPageChange(currentPage - 1);
+  };
+
+  const handleNext = () => {
+    if (currentPage > totalPageNumber) return;
+    onPageChange(currentPage + 1);
+  };
+
+  const renderPageNumbers = () => {
+    if (totalPageNumber <= 5) {
+      return Array.from({ length: totalPageNumber }).map((_, i) => i + 1);
+    }
+
+    return Array.from({ length: MAX_LIMIT }).map((_, i) => {
+      if (currentPage <= 2) {
+        return i + 1;
+      }
+
+      if (currentPage >= totalPageNumber - 1) {
+        return totalPageNumber - MAX_LIMIT + i + 1;
+      }
+
+      return i + currentPage - Math.floor((MAX_LIMIT - 1) / 2);
+    });
+  };
+
+  if (totalPageNumber <= 1) return null;
+
+  return (
+    <nav aria-label="pagination" className={cx(styles.pagination, className)}>
+      <Button
+        disabled={currentPage === 1}
+        onClick={handlePrevious}
+        small
+        text
+        type="button"
+      >
+        Prev
+      </Button>
+      <ul className={styles.paginationList}>
+        {renderPageNumbers().map((pageNumber) => (
+          <li key={pageNumber}>
+            <Button
+              small
+              text
+              type="button"
+              onClick={() => onPageChange(pageNumber)}
+              buttonClassName={cx({
+                [styles.selected]: currentPage === pageNumber,
+              })}
+            >
+              {pageNumber}
+            </Button>
+          </li>
+        ))}
+      </ul>
+      <Button
+        disabled={currentPage === totalPageNumber}
+        onClick={handleNext}
+        small
+        text
+        type="button"
+      >
+        Next
+      </Button>
+    </nav>
+  );
+}

--- a/components/pagination/index.tsx
+++ b/components/pagination/index.tsx
@@ -3,7 +3,6 @@ import Button from "@/components/button";
 import styles from "./index.module.css";
 
 interface PaginationProps {
-  className?: string;
   currentPage: number;
   itemsPerPage: number;
   onPageChange: (value: number) => void;
@@ -13,8 +12,7 @@ interface PaginationProps {
 const MAX_LIMIT = 5;
 
 export default function Pagination(props: PaginationProps) {
-  const { className, currentPage, itemsPerPage, onPageChange, totalItems } =
-    props;
+  const { currentPage, itemsPerPage, onPageChange, totalItems } = props;
 
   const totalPageNumber = Math.ceil(totalItems / itemsPerPage);
 
@@ -49,7 +47,7 @@ export default function Pagination(props: PaginationProps) {
   if (totalPageNumber <= 1) return null;
 
   return (
-    <nav aria-label="pagination" className={cx(styles.pagination, className)}>
+    <nav aria-label="pagination" className={styles.pagination}>
       <Button
         disabled={currentPage === 1}
         onClick={handlePrevious}

--- a/components/quiz/answers/answer/index.module.css
+++ b/components/quiz/answers/answer/index.module.css
@@ -8,7 +8,7 @@
   font-weight: 500;
   font-size: 18px;
   border-radius: 30px;
-  border: 1px solid #f3f3f3;
+  border: 1px solid var(--border-color);
   margin: 0 0 5px;
 }
 

--- a/components/quiz/answers/index.module.css
+++ b/components/quiz/answers/index.module.css
@@ -2,6 +2,6 @@
   /* border: 1px solid #dfdfdf; */
   max-width: 400px;
   margin: 0 auto;
-  border-radius: 5px;
+  border-radius: var(--border-radius-small);
   overflow: hidden;
 }

--- a/components/quiz/playersList/index.module.css
+++ b/components/quiz/playersList/index.module.css
@@ -1,0 +1,51 @@
+.topRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.topRow > h3 {
+  margin: 0;
+}
+
+.place {
+  border-radius: 50%;
+  color: var(--text-color);
+  display: block;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  width: 28px;
+}
+
+.gold {
+  background: linear-gradient(180deg, #ffd600 0%, #ffcd1d 6.96%, #ffae28 100%);
+}
+
+.silver {
+  background: linear-gradient(180deg, #c0c0c0 0%, #d3d3d3 50%, #a9a9a9 100%);
+}
+
+.bronze {
+  background: linear-gradient(180deg, #cd7f32 0%, #b87333 50%, #8c4a2d 100%);
+  color: white;
+}
+
+@media (min-width: 568px) {
+  .queryField {
+    width: 260px;
+  }
+}
+
+@media (max-width: 567px) {
+  .topRow {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .queryField {
+    width: 100%;
+  }
+}

--- a/components/quiz/playersList/index.tsx
+++ b/components/quiz/playersList/index.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import cx from "classnames";
+import { debounce } from "@/scripts/debounce";
+import { InputChangeType } from "@/types/form";
+import { Leaderboard, LeaderboardEntry } from "@/types/quiz";
+import FormGroup from "@/components/formGroup";
+import Input from "@/components/input";
+import Pagination from "@/components/pagination";
+import Table, { ColumnProps } from "@/components/table";
+import styles from "./index.module.css";
+
+interface PlayersResultProps {
+  leaderboard: Leaderboard;
+}
+
+const ITEMS_PER_PAGE = 20;
+
+export default function PlayersResult(props: PlayersResultProps) {
+  const { leaderboard } = props;
+
+  const [page, setPage] = useState(1);
+  const [query, setQuery] = useState("");
+
+  const debouncedValue = useMemo(
+    () => debounce((value: string) => setQuery(value)),
+    [setQuery]
+  );
+
+  const handleChange = (e: InputChangeType) => {
+    setPage(1);
+    debouncedValue(e.target.value);
+  };
+
+  const dataWithQuery = query
+    ? leaderboard?.filter((item) =>
+        item.name?.toLowerCase().includes(query.toLowerCase())
+      )
+    : leaderboard;
+
+  const startIndex = (page - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const dataWithPaging = dataWithQuery?.slice(startIndex, endIndex);
+
+  const columns: Array<ColumnProps<LeaderboardEntry>> = [
+    {
+      key: "rank",
+      title: "Place",
+      render: (item) => (
+        <div
+          className={cx(styles.place, {
+            [styles.gold]: item?.rank === 1,
+            [styles.silver]: item?.rank === 2,
+            [styles.bronze]: item?.rank === 3,
+          })}
+        >
+          {item?.rank}
+        </div>
+      ),
+    },
+    {
+      key: "name",
+      title: "Player name",
+    },
+    {
+      key: "score",
+      title: "Score",
+    },
+  ];
+
+  return (
+    <>
+      <div className={styles.topRow}>
+        <h3>Other Players</h3>
+        <FormGroup
+          className={styles.queryField}
+          label="Search for the player's name"
+          isLabelHidden
+        >
+          <Input
+            onChange={handleChange}
+            placeholder="Search for the player's name"
+            variant="input"
+          />
+        </FormGroup>
+      </div>
+      <Table data={dataWithPaging} columns={columns} />
+      <Pagination
+        currentPage={page}
+        itemsPerPage={ITEMS_PER_PAGE}
+        onPageChange={setPage}
+        totalItems={dataWithQuery?.length}
+      />
+    </>
+  );
+}

--- a/components/quiz/playersResult/index.module.css
+++ b/components/quiz/playersResult/index.module.css
@@ -13,7 +13,6 @@
 .place {
   border-radius: 50%;
   color: var(--text-color);
-  display: block;
   height: 28px;
   line-height: 28px;
   text-align: center;

--- a/components/quiz/playersResult/index.tsx
+++ b/components/quiz/playersResult/index.tsx
@@ -72,15 +72,15 @@ export default function PlayersResult(props: PlayersResultProps) {
   return (
     <>
       <div className={styles.topRow}>
-        <h3>Other Players</h3>
+        <h3>Players Ranking</h3>
         <FormGroup
           className={styles.queryField}
-          label="Search for the player's name"
+          label="Search by player name"
           isLabelHidden
         >
           <Input
             onChange={handleChange}
-            placeholder="Search for the player's name"
+            placeholder="Search by player name"
             variant="input"
           />
         </FormGroup>

--- a/components/quiz/userNameForm/index.module.css
+++ b/components/quiz/userNameForm/index.module.css
@@ -1,0 +1,7 @@
+.container {
+  width: 100%;
+}
+
+.startButton {
+  margin: 40px auto 0;
+}

--- a/components/quiz/userNameForm/index.tsx
+++ b/components/quiz/userNameForm/index.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useContext, useState } from "react";
+import { InputChangeType } from "@/types/form";
+import { QuizContext } from "@/context/quiz";
+import { useRouter } from "next/navigation";
+import Button from "@/components/button";
+import FormGroup from "@/components/formGroup";
+import Input from "@/components/input";
+import styles from "./index.module.css";
+
+export default function UserNameForm() {
+  const { setUserName } = useContext(QuizContext);
+
+  const [localUserName, setLocalUserName] = useState("");
+  const [validationError, setValidationError] = useState("");
+
+  const router = useRouter();
+
+  const handleChange = (e: InputChangeType) => {
+    const value = e.target.value;
+
+    if (value.trim()) {
+      setValidationError("");
+    }
+
+    setLocalUserName(value);
+  };
+
+  const handleClick = () => {
+    if (!localUserName.trim()) {
+      setValidationError("Enter your name");
+      return;
+    }
+
+    setUserName(localUserName);
+    router.push("/quiz/question/1");
+  };
+
+  return (
+    <div className={styles.container}>
+      <FormGroup label="Enter your name" isLabelHidden error={validationError}>
+        <Input
+          large
+          onChange={handleChange}
+          placeholder="Enter your name"
+          variant="input"
+        />
+      </FormGroup>
+      <Button
+        buttonClassName={styles.startButton}
+        large
+        onClick={handleClick}
+        type="button"
+      >
+        Start
+      </Button>
+    </div>
+  );
+}

--- a/components/quiz/userNameForm/index.tsx
+++ b/components/quiz/userNameForm/index.tsx
@@ -29,7 +29,7 @@ export default function UserNameForm() {
 
   const handleClick = () => {
     if (!localUserName.trim()) {
-      setValidationError("Enter your name");
+      setValidationError("Name is required");
       return;
     }
 
@@ -49,6 +49,7 @@ export default function UserNameForm() {
       </FormGroup>
       <Button
         buttonClassName={styles.startButton}
+        disabled={!localUserName.trim()}
         large
         onClick={handleClick}
         type="button"

--- a/components/quiz/userResult/index.module.css
+++ b/components/quiz/userResult/index.module.css
@@ -27,12 +27,12 @@
   padding: 10px;
 }
 
-.label {
-  color: #696e7b;
-  display: block;
-  margin-top: 4px;
-}
-
 .detail + .detail {
   border-left: 1px solid var(--border-color);
+}
+
+.label {
+  color: var(--text-light-color);
+  display: block;
+  margin-top: 4px;
 }

--- a/components/quiz/userResult/index.module.css
+++ b/components/quiz/userResult/index.module.css
@@ -1,0 +1,38 @@
+.container {
+  border-radius: var(--border-radius);
+  box-shadow: 2px 8px 30px 0px #ececec;
+  margin: 40px auto;
+  max-width: 400px;
+  text-align: center;
+}
+
+.result {
+  padding: 10px 20px;
+}
+
+.scores {
+  line-height: 1.4;
+}
+
+.details {
+  align-items: center;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: center;
+}
+
+.detail {
+  flex: 1;
+  font-size: 14px;
+  padding: 10px;
+}
+
+.label {
+  color: #696e7b;
+  display: block;
+  margin-top: 4px;
+}
+
+.detail + .detail {
+  border-left: 1px solid var(--border-color);
+}

--- a/components/quiz/userResult/index.tsx
+++ b/components/quiz/userResult/index.tsx
@@ -1,6 +1,6 @@
 import styles from "./index.module.css";
 
-interface PaginationProps {
+interface UserResultProps {
   skillScore: number;
   totalQuestions: number;
   totalScore: number;
@@ -10,7 +10,7 @@ interface PaginationProps {
 
 const SUCCESS_PERCENT = 0.8;
 
-export default function UserResult(props: PaginationProps) {
+export default function UserResult(props: UserResultProps) {
   const { skillScore, totalQuestions, totalScore, userName, userScore } = props;
 
   const successRate = Math.round(totalQuestions * SUCCESS_PERCENT);

--- a/components/quiz/userResult/index.tsx
+++ b/components/quiz/userResult/index.tsx
@@ -1,0 +1,46 @@
+import styles from "./index.module.css";
+
+interface PaginationProps {
+  skillScore: number;
+  totalQuestions: number;
+  totalScore: number;
+  userName: string;
+  userScore: number;
+}
+
+const SUCCESS_PERCENT = 0.8;
+
+export default function UserResult(props: PaginationProps) {
+  const { skillScore, totalQuestions, totalScore, userName, userScore } = props;
+
+  const successRate = Math.round(totalQuestions * SUCCESS_PERCENT);
+  const title = userScore < successRate ? "🥺 Sorry" : "🎉 Congratulations";
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.result}>
+        <h2>
+          {title}, {userName}!
+        </h2>
+        <p className={styles.scores}>
+          Your skill score <strong>{skillScore}</strong>, totaling{" "}
+          <strong>{totalScore}</strong>
+        </p>
+      </div>
+      <div className={styles.details}>
+        <div className={styles.detail}>
+          {totalQuestions}
+          <span className={styles.label}>Questions</span>
+        </div>
+        <div className={styles.detail}>
+          {userScore}
+          <span className={styles.label}>Correct</span>
+        </div>
+        <div className={styles.detail}>
+          {totalQuestions - userScore}
+          <span className={styles.label}>Failed</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/table/index.module.css
+++ b/components/table/index.module.css
@@ -1,0 +1,41 @@
+.table {
+  max-width: 100%;
+  min-width: 660px;
+  overflow-x: auto;
+}
+
+@media (max-width: 767px) {
+  .table {
+    min-width: 100%;
+  }
+}
+
+.row {
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.row:not(.rowHead) {
+  min-height: 40px;
+}
+
+.col {
+  flex: 1;
+  padding: 10px 15px;
+}
+
+.colHead {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.col:first-child {
+  flex: 15% 0 0;
+}
+
+.col:last-child {
+  flex: 15% 0 0;
+}

--- a/components/table/index.tsx
+++ b/components/table/index.tsx
@@ -1,0 +1,45 @@
+import { ReactElement } from "react";
+import cx from "classnames";
+import styles from "./index.module.css";
+
+export interface ColumnProps<T> {
+  key: string;
+  title: string | ReactElement;
+  render?: (item: T) => ReactElement;
+}
+
+interface TableProps<T> {
+  columns: Array<ColumnProps<T>>;
+  data?: T[];
+}
+
+export default function Table<T>(props: TableProps<T>) {
+  const { columns, data } = props;
+
+  return (
+    <div className={styles.table}>
+      <div className={cx(styles.row, styles.rowHead)}>
+        {columns.map((column) => (
+          <div className={cx(styles.col, styles.colHead)} key={column.key}>
+            {column.title}
+          </div>
+        ))}
+      </div>
+      {data?.map((item, itemIndex) => (
+        <div className={styles.row} key={`row-${itemIndex}`}>
+          {columns.map((column, columnIndex) => {
+            const value = column.render
+              ? column.render(item)
+              : (item[column.key as keyof T] as string);
+
+            return (
+              <div className={styles.col} key={`cell-${columnIndex}`}>
+                {value}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/context/quiz.tsx
+++ b/context/quiz.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { QuizQuestion, UserAnswers } from "@/types/quiz";
 import { createContext, useEffect, useContext, useState } from "react";
 
@@ -12,12 +14,15 @@ export const QuizContext = createContext({
   }) => {},
   questions: [] as QuizQuestion[],
   failed: false,
+  userName: "",
+  setUserName: (name: string) => {},
 });
 
 export function AppWrapper({ children }: { children: React.ReactNode }) {
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
   const [userAnswers, setUserAnswers] = useState<UserAnswers>({});
   const [failed, setFailed] = useState(false);
+  const [userName, setUserName] = useState("");
 
   useEffect(() => {
     const loadQuestions = async () => {
@@ -56,6 +61,8 @@ export function AppWrapper({ children }: { children: React.ReactNode }) {
         answerQuestion,
         questions,
         failed,
+        userName,
+        setUserName,
       }}
     >
       {children}

--- a/scripts/debounce.js
+++ b/scripts/debounce.js
@@ -1,0 +1,8 @@
+export const debounce = (fn, ms = 500) => {
+  let timeoutId;
+
+  return function (args) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(args), ms);
+  };
+};

--- a/types/common.ts
+++ b/types/common.ts
@@ -1,0 +1,1 @@
+export type IconType = "leftarrow" | "tick";

--- a/types/form.ts
+++ b/types/form.ts
@@ -1,0 +1,4 @@
+export type InputElementType = React.InputHTMLAttributes<HTMLInputElement>;
+export type TextareaElementType =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+export type InputChangeType = React.ChangeEvent<HTMLInputElement>;

--- a/types/quiz.ts
+++ b/types/quiz.ts
@@ -27,4 +27,5 @@ export type LeaderboardEntry = {
   id: string;
   name: string;
   score: number;
+  rank: number;
 };


### PR DESCRIPTION
Good morning! Thank you for the technical task.

In the current implementation, I decided to handle everything on the FE side. This approach avoids sending a POST request for each parameter change, which would otherwise repeatedly save the user's name and update the leaderboard.

The ideal solution would be to implement pagination and search functionality through BE. This way, we can separate the concerns: POST request to save the data and GET request to retrieve and filter the leaderboard.

Additionally, I decided not to modify the URL or add query parameters. Since the page redirects to the main page upon updating, including queries in the URL seemed unnecessary in this context.